### PR TITLE
Use XML metadata fallback in token counts

### DIFF
--- a/QC/count_tokens.py
+++ b/QC/count_tokens.py
@@ -3,6 +3,26 @@ import os
 import argparse
 import json
 from collections import defaultdict
+
+LANG_CODE_TO_NAME = {
+    'ami': 'Amis',
+    'tay': 'Atayal',
+    'pwn': 'Paiwan',
+    'bnn': 'Bunun',
+    'pyu': 'Puyuma',
+    'dru': 'Rukai',
+    'tsu': 'Tsou',
+    'xsy': 'Saisiyat',
+    'tao': 'Yami',
+    'ssf': 'Thao',
+    'ckv': 'Kavalan',
+    'trv': 'Seediq',
+    'szy': 'Sakizaya',
+    'sxr': 'Saaroa',
+    'xnb': 'Kanakanavu',
+    'fos': 'Siraya',
+}
+
 # Determine the language of the file based on the path
 def get_lang(path, file, langs):
     for lang in langs:
@@ -15,6 +35,7 @@ def read_file(file_path):
     num_words = 0
     tree = ET.parse(file_path)
     root = tree.getroot()
+    xml_lang = root.attrib.get('{http://www.w3.org/XML/1998/namespace}lang')
     if "dialect" in root.attrib:
         dialect = root.attrib['dialect']
     else:
@@ -30,7 +51,7 @@ def read_file(file_path):
             # Count the number of words
             num_words += len(words)
 
-    return num_words, dialect
+    return num_words, dialect, xml_lang
 
 def count_source(path, tokens_by_lang, langs):
     source_total = 0
@@ -39,7 +60,12 @@ def count_source(path, tokens_by_lang, langs):
             if file.endswith(".xml") and 'XML' in os.path.join(root, file):
                 # print(root, file)
                 lang = get_lang(root, file, langs)
-                tokens_in_file, dialect = read_file(os.path.join(root, file))
+                file_path = os.path.join(root, file)
+                tokens_in_file, dialect, xml_lang = read_file(file_path)
+                if lang is None and xml_lang:
+                    lang = LANG_CODE_TO_NAME.get(xml_lang)
+                if lang is None:
+                    raise ValueError(f"Could not determine language for XML file: {file_path}")
                 if dialect:
                     tokens_by_lang[lang][1][dialect] += tokens_in_file
                 else:


### PR DESCRIPTION
## Summary

- Make `QC/count_tokens.py` fall back to XML root `xml:lang` when language cannot be inferred from the path.
- Map FormosanBank ISO 639-3 codes back to the existing language names used by the token count output.
- Raise a clear `ValueError` with the file path if neither path nor XML metadata identifies the language.

## Context

The `Token Count Delta` workflow failed when running the current script against an older baseline commit. Older valid corpus layouts include paths such as `Corpora/RauDong/XML/*.xml` and `Corpora/MontgomeryTexts/XML/*.xml`; these paths do not include `Yami` or `Amis`, but their XML roots do contain valid `xml:lang` values like `tao` and `ami`.

This PR does not change corpus XML or token-count semantics. It only prevents the counter from crashing when an XML file's language is available in metadata but not inferable from its path.

Closes #34.

## Verification

Locally ran the patched counter against both the old baseline commit selected by the workflow (`ae7402c9`, dated 2025-08-10) and the current checkout:

```bash
python3 -m py_compile QC/count_tokens.py
python3 QC/count_tokens.py /tmp/formosanbank-old-token-check/Corpora > /tmp/old_token_count_ci_pr.json
python3 QC/count_tokens.py ./Corpora > /tmp/current_token_count_ci_pr.json
```

Results:

- old baseline count completed: 17 languages, 7,927,976 total tokens
- current count completed: 17 languages, 7,324,341 total tokens

The lower current total is from repository corpus changes between the six-month-old baseline and current `main`, not from this PR. The delta is dominated by `ePark`:

- old `Corpora/ePark/XML`: 646 XML files, 2,680,175 tokens
- current `Corpora/ePark/XML`: 436 XML files, 1,789,191 tokens
- `ePark` delta: -890,984 tokens

Other current additions partly offset that, including `NTUFormosanCorpus` (+148,826), `Glosbe` (+92,304), `WilangYutasVideos` (+25,020), and `HundredPaiwanStories` (+24,478).
