### PR TITLE
Improve QC script usability and docs

### DIFF
--- a/QC/README.md
+++ b/QC/README.md
@@ -1,0 +1,117 @@
+# FormosanBank QC
+
+This folder contains lightweight scripts for checking FormosanBank XML corpora. The scripts are intentionally modular: run the checks that match the corpus state instead of treating every warning as an automatic data error.
+
+## Expected XML Tiers
+
+Most validation scripts inspect the standardized sentence tier:
+
+```xml
+<S id="...">
+    <FORM kindOf="original">...</FORM>
+    <FORM kindOf="standard">...</FORM>
+</S>
+```
+
+If a corpus only has one sentence-level `FORM`, create the standard tier first:
+
+```bash
+python QC/utilities/standardize.py \
+  --copy \
+  --corpora_path /path/to/corpus-or-Final_XML
+```
+
+`--copy` does not normalize spelling. It preserves the source text as `kindOf="original"` and creates `kindOf="standard"` as an exact copy so the QC scripts have a consistent tier to inspect.
+
+To actually normalize orthography, provide a TSV mapping:
+
+```bash
+python QC/utilities/standardize.py \
+  --corpora_path /path/to/corpus-or-Final_XML \
+  --tsv_path /path/to/orthography-map.tsv \
+  --target_column standard
+```
+
+The TSV must include an `original` column and a target column such as `standard` or a dialect name. Replacements are applied globally and sequentially with Python string replacement, so review the diff after running it.
+
+## Basic Flow
+
+Run XML validation first:
+
+```bash
+python QC/validation/validate_xml.py by_path \
+  --path /path/to/Final_XML
+```
+
+Run punctuation validation after `FORM kindOf="standard"` exists:
+
+```bash
+python QC/validation/validate_punct.py by_path \
+  --path /path/to/Final_XML
+```
+
+Extract orthographic information from the standard tier:
+
+```bash
+python QC/orthography/orthography_extract.py \
+  --corpora_path /path/to/Final_XML \
+  --corpus all \
+  --language All \
+  --kindOf standard \
+  --by_dialect true \
+  --output_dir /path/to/qc-output/extract_logs
+```
+
+Compare orthography and vocabulary against the reference data:
+
+```bash
+python QC/validation/validate_orthography.py \
+  --o_info /path/to/qc-output/extract_logs \
+  --reference QC/validation/reference
+
+python QC/validation/validate_vocabulary.py \
+  --o_info /path/to/qc-output/extract_logs \
+  --reference QC/validation/reference
+```
+
+Run gloss validation only when the corpus is expected to contain word-level `W` elements, and morpheme validation only when `M` elements are expected:
+
+```bash
+python QC/validation/validate_glosses.py /path/to/Final_XML \
+  --output_dir /path/to/qc-output
+
+python QC/validation/validate_glosses.py /path/to/Final_XML \
+  --check_morpho \
+  --output_dir /path/to/qc-output
+```
+
+For verse-level or sentence-only corpora with no `W`/`M` segmentation, `validate_glosses.py` will report sentence/W mismatches. Treat those as "not applicable" unless word segmentation is required for that corpus.
+
+## Output Locations
+
+Use explicit output directories when you do not want logs or CSVs written beside the scripts or inside the corpus:
+
+```bash
+python QC/validation/validate_xml.py by_path \
+  --path /path/to/Final_XML \
+  --verbose \
+  --log_dir /path/to/qc-output/logs
+
+python QC/validation/validate_punct.py by_path \
+  --path /path/to/Final_XML \
+  --verbose \
+  --log_dir /path/to/qc-output/logs
+```
+
+`orthography_extract.py --output_dir` writes extracted `orthographic_info` files and plots to that directory.
+
+`validate_glosses.py --output_dir` writes:
+
+- `validation_results.csv`
+- `validation_m_mismatches.csv`
+
+## Interpreting Common Warnings
+
+- `No reference orthographic info found`: the extracted language/dialect folder does not match a folder under `QC/validation/reference`. Normalize dialect labels before treating this as an orthography failure.
+- Punctuation `non_ascii_characters`: this excludes Chinese characters, but it still flags diacritics, IPA, smart quotes, and other non-ASCII symbols. Review whether these are expected for the source.
+- Vocabulary overlap warnings: these are useful for review, but they can be noisy when comparing texts from different genres, such as Bibles against dictionaries or narratives.

--- a/QC/orthography/orthography_extract.py
+++ b/QC/orthography/orthography_extract.py
@@ -22,6 +22,16 @@ plt.rcParams['font.sans-serif'] = ['Arial Unicode MS']
 # Set the font properties globally
 #plt.rcParams['font.family'] = 'Noto Sans'
 
+
+def parse_bool(value):
+    if isinstance(value, bool):
+        return value
+    if value.lower() in {"1", "true", "t", "yes", "y"}:
+        return True
+    if value.lower() in {"0", "false", "f", "no", "n"}:
+        return False
+    raise argparse.ArgumentTypeError("Expected a boolean value such as true or false.")
+
 def generate_corpus(language_to_process, to_check_path, kindOf, by_dialect=False):
     corpus = {}
     if not by_dialect:
@@ -412,7 +422,12 @@ def visualize(o_info, output_folder):
     plt.close()
 
 def main(args, langs):
-    logs_dir = os.path.join(args.corpora_path, "extract_logs")
+    if args.corpus == "all":
+        to_check_path = args.corpora_path
+    else:
+        to_check_path = os.path.join(args.corpora_path, args.corpus)
+
+    logs_dir = args.output_dir or os.path.join(to_check_path, "extract_logs")
     os.makedirs(logs_dir, exist_ok=True)
 
     if args.language == 'All':
@@ -423,7 +438,7 @@ def main(args, langs):
     for language in languages_to_process:
         corpus = None
 
-        corpus = generate_corpus(language, args.corpora_path, args.kindOf, args.by_dialect)
+        corpus = generate_corpus(language, to_check_path, args.kindOf, args.by_dialect)
         for corp in corpus.keys():
             if corpus[corp]:
                 o_info = extract_orthographic_info(corpus[corp])
@@ -435,7 +450,7 @@ def main(args, langs):
                 with open(os.path.join(output_folder, "orthographic_info"), 'wb') as fp:
                     pickle.dump(o_info, fp)
                 visualize(o_info, output_folder)
-                print(f"Successfully extracted orthographic information for {corp} from {language} using {args.corpora_path}")
+                print(f"Successfully extracted orthographic information for {corp} from {language} using {to_check_path}")
             else:
                 print(f"Warning: Unable to extract the orthographic information for {corp} from {language}. generate_corpus function didn't return any corpus")
     
@@ -450,7 +465,10 @@ if __name__ == "__main__":
     parser.add_argument('--corpus', help='Set to "all" to process all corpora in the corpora_path. Otherwise, provide name of corpus.')
     parser.add_argument('--language', help='Language code')
     parser.add_argument('--kindOf', help='which XML tier to consider. Defaults to all, which is a problem if there is both an original and standard tier.')
-    parser.add_argument('--by_dialect', help='If set to True, will process corpora by dialect')
+    parser.add_argument('--by_dialect', nargs='?', const=True, default=False, type=parse_bool,
+                        help='Process corpora by dialect. Accepts true/false; passing the flag alone means true.')
+    parser.add_argument('--output_dir',
+                        help='Directory for extracted orthographic info and plots. Defaults to <corpus>/extract_logs.')
     args = parser.parse_args()
 
     # Validate required arguments
@@ -460,6 +478,6 @@ if __name__ == "__main__":
         parser.error(f"The entered path, {args.corpora_path}, doesn't exist")
     if args.language != "All" and not args.language in langs:
         parser.error(f"Enter a valid Formosan language from the list: {langs}")
-    if not args.by_dialect:
-        args.by_dialect = False
+    if args.corpus != "all" and not os.path.exists(os.path.join(args.corpora_path, args.corpus)):
+        parser.error(f"The entered corpus doesn't exist: {os.path.join(args.corpora_path, args.corpus)}")
     main(args, langs)

--- a/QC/validation/validate_glosses.py
+++ b/QC/validation/validate_glosses.py
@@ -208,6 +208,8 @@ Examples:
                        help='Check if each W element has at least one M element')
     parser.add_argument('--debug', action='store_true',
                        help='Enable debug output showing detailed parsing information')
+    parser.add_argument('--output_dir',
+                       help='Directory for validation CSV outputs. Defaults to the current working directory.')
     
     args = parser.parse_args()
     
@@ -218,8 +220,10 @@ Examples:
         sys.exit(1)
     
     # Setup output CSVs
-    w_csv_file = Path('validation_results.csv')
-    m_csv_file = Path('validation_m_mismatches.csv')
+    output_dir = Path(args.output_dir) if args.output_dir else Path.cwd()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    w_csv_file = output_dir / 'validation_results.csv'
+    m_csv_file = output_dir / 'validation_m_mismatches.csv'
 
     print(f"Validating XML files in: {xml_folder}")
     print(f"Check morphemes (W missing M): {args.check_morpho}")

--- a/QC/validation/validate_punct.py
+++ b/QC/validation/validate_punct.py
@@ -98,15 +98,24 @@ def analyze_xml_file(xml_file, lang_codes, args):
 def analyze_directory(xml_dir, lang_codes, args):
     directory_issues = defaultdict(lambda: defaultdict(int))
 
-    for root, _, files in os.walk(xml_dir):
-        for file in files:
-            if file.endswith(".xml"):
-                xml_path = os.path.join(root, file)
-                parent_dir = os.path.dirname(xml_path)
-                file_issues = analyze_xml_file(xml_path, lang_codes, args)
+    if os.path.isfile(xml_dir):
+        xml_files = [xml_dir] if xml_dir.endswith(".xml") else []
+    else:
+        xml_files = [
+            os.path.join(root, file)
+            for root, _, files in os.walk(xml_dir)
+            for file in files
+            if file.endswith(".xml")
+        ]
 
-                for issue_type, count in file_issues.items():
-                    directory_issues[parent_dir][issue_type] += count
+    for xml_path in xml_files:
+        if args.search_by == "by_language" and get_lang(xml_path, lang_codes) != args.language:
+            continue
+        parent_dir = os.path.dirname(xml_path)
+        file_issues = analyze_xml_file(xml_path, lang_codes, args)
+
+        for issue_type, count in file_issues.items():
+            directory_issues[parent_dir][issue_type] += count
 
     return directory_issues
 
@@ -139,6 +148,8 @@ def main():
     parser.add_argument('--corpora_path', help='Path to corpora directory (required for by_language and by_corpus)')
     parser.add_argument('--path', help='Path to XML file or directory (required for by_path)')
     parser.add_argument('--corpus', help='Corpus name (required for by_corpus)')
+    parser.add_argument('--log_dir',
+                        help='Directory for verbose logs. Defaults to QC/validation/logs.')
     args = parser.parse_args()
 
     langs = ["Amis", "Atayal", "Paiwan", "Bunun", "Puyuma", "Rukai", "Tsou", "Saisiyat", "Yami",
@@ -146,7 +157,7 @@ def main():
 
     if args.verbose:
         curr_dir = os.path.dirname(os.path.abspath(__file__))
-        log_dir = os.path.join(curr_dir, "logs")
+        log_dir = args.log_dir or os.path.join(curr_dir, "logs")
         os.makedirs(log_dir, exist_ok=True)
 
         log_file_path = os.path.join(log_dir, f"punctuation_validation_log_{args.search_by}.txt")
@@ -160,7 +171,19 @@ def main():
 
     lang_codes = {lang: lang.lower() for lang in langs}
 
-    corpora_dir = args.corpora_path if args.search_by != 'by_path' else os.path.dirname(args.path)
+    if args.search_by == 'by_path':
+        if not args.path:
+            parser.error("For 'by_path', --path is required.")
+        corpora_dir = args.path
+    elif args.search_by == 'by_corpus':
+        if not args.corpora_path or not args.corpus:
+            parser.error("For 'by_corpus', --corpora_path and --corpus are required.")
+        corpora_dir = os.path.join(args.corpora_path, args.corpus)
+    else:
+        if not args.corpora_path:
+            parser.error("For 'by_language', --corpora_path is required.")
+        corpora_dir = args.corpora_path
+
     directory_issues = analyze_directory(corpora_dir, lang_codes, args)
 
     generate_report(directory_issues, "Directory")

--- a/QC/validation/validate_xml.py
+++ b/QC/validation/validate_xml.py
@@ -1,9 +1,20 @@
 from lxml import etree
 import os
-import pandas as pd
 import argparse
 import logging
 import xml.etree.ElementTree as ET
+import csv
+
+XML_NAMESPACE_XSD = """\
+<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://www.w3.org/XML/1998/namespace"
+           xmlns:xml="http://www.w3.org/XML/1998/namespace"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified">
+  <xs:attribute name="lang" type="xs:language"/>
+</xs:schema>
+"""
 
 
 '''
@@ -29,6 +40,22 @@ def get_log_file_name(args):
     else:
         log_file_name = "validation_log.txt"
     return log_file_name
+
+
+def load_iso_639_3_codes(path):
+    """Load ISO 639-3 identifiers without requiring pandas."""
+    with open(path, newline='', encoding='utf-8') as iso_file:
+        reader = csv.DictReader(iso_file, delimiter='\t')
+        return {row['Id'] for row in reader if row.get('Id')}
+
+
+class XmlNamespaceResolver(etree.Resolver):
+    """Resolve the W3C xml namespace import locally for consistent XSD loading."""
+
+    def resolve(self, url, pubid, context):
+        if url == "http://www.w3.org/2001/xml.xsd":
+            return self.resolve_string(XML_NAMESPACE_XSD, context)
+        return None
 
 # Get the language being analyzed from the path
 def get_lang(path, langs):
@@ -188,12 +215,12 @@ def get_files(path, to_check, lang, langs):
 # Main process call subfunctions, log issues, and print summary
 def main(args, langs):
     curr_dir = os.path.dirname(os.path.abspath(__file__))
-    iso6393_3 = pd.read_csv(os.path.join(curr_dir, 'iso-639-3.txt'), sep='\t')
-    langs_codes = set(iso6393_3['Id'])
+    langs_codes = load_iso_639_3_codes(os.path.join(curr_dir, 'iso-639-3.txt'))
     xsd_file = os.path.join(curr_dir, "xml_template.xsd")
     # Parse the XSD file
-    with open(xsd_file, 'r') as schema_file:
-        schema_root = etree.parse(schema_file)
+    schema_parser = etree.XMLParser()
+    schema_parser.resolvers.add(XmlNamespaceResolver())
+    schema_root = etree.parse(xsd_file, schema_parser)
     schema = etree.XMLSchema(schema_root)
     
     to_check = list()
@@ -256,6 +283,8 @@ if __name__ == "__main__":
     parser.add_argument('--corpora_path', help='Path to corpora directory (required for by_language and by_corpus)')
     parser.add_argument('--path', help='Path to XML file or directory (required for by_path)')
     parser.add_argument('--corpus', help='Corpus name (required for by_corpus)')
+    parser.add_argument('--log_dir',
+                        help='Directory for verbose logs. Defaults to QC/validation/logs.')
     args = parser.parse_args()
 
     # Validate required arguments based on 'search_by'
@@ -280,7 +309,7 @@ if __name__ == "__main__":
     # Set up logging only if verbose is True
     if args.verbose:
         curr_dir = os.path.dirname(os.path.abspath(__file__))
-        log_dir = os.path.join(curr_dir, "logs")
+        log_dir = args.log_dir or os.path.join(curr_dir, "logs")
         os.makedirs(log_dir, exist_ok=True)
 
         log_file_name = get_log_file_name(args)


### PR DESCRIPTION
## Summary
- Add a QC README documenting the standard QC flow, including when to run standardize.py --copy versus TSV-based normalization.
- Make validate_xml.py less environment-sensitive by removing the pandas dependency and resolving the xml:lang XSD import locally.
- Fix validate_punct.py by_path so it checks the provided path instead of the parent directory, and support single-file paths.
- Add explicit output directory options for verbose validation logs, gloss CSVs, and orthography extraction logs.
- Make orthography_extract.py honor --corpus and parse --by_dialect as a real boolean.

## Verification
- python3 -m py_compile QC/validation/validate_xml.py QC/validation/validate_punct.py QC/validation/validate_glosses.py QC/orthography/orthography_extract.py
- python3 QC/validation/validate_xml.py by_path --path Corpora/HundredPaiwanStories/XML/PaiwanCh2_024.xml
- python3 QC/validation/validate_punct.py by_path --path Corpora/HundredPaiwanStories/XML/PaiwanCh2_024.xml
- python3 QC/validation/validate_punct.py by_path --path Corpora/HundredPaiwanStories/XML/PaiwanCh2_024.xml --verbose --log_dir /tmp/formosan_qc_logs
- python3 QC/validation/validate_glosses.py Corpora/HundredPaiwanStories/XML --output_dir /tmp/formosan_qc_gloss_test
- python3 QC/orthography/orthography_extract.py --corpora_path Corpora --corpus HundredPaiwanStories --language Paiwan --kindOf standard --by_dialect false --output_dir /tmp/formosan_qc_extract_test

Note: the sample XML validation command correctly reports existing PHON/XSD issues in the sample file; it is included here to verify the script loads and reports validation results.