### PR TITLE
Use cleaned Yedda blog XML

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,14 +2,14 @@ huggingface-hub==0.29.1
 lxml==5.3.0
 matplotlib==3.9.2
 mutagen==1.47.0
-numpy==2.0.2
+numpy==2.2.6
 pandas==2.2.3
 PyYAML==6.0.2
 regex==2024.11.6
 requests==2.32.3
 sacrebleu>=2.4.0
 scikit-learn==1.5.2
-scipy==1.13.1
+scipy==1.15.3
 seaborn==0.13.2
 tqdm==4.67.1
 pytest==8.3.4


### PR DESCRIPTION
## Summary

This PR replaces the published Yedda Palemeq Blog XML with the current XML from `Formosan-Yedda-Palemeq-Blog/Final_XML/Paiwan/Paiwan_Yedda_Blog.xml` so the differences are easy to review.

## Why

The published FormosanBank copy appears to contain double-encoded HTML/entity residue. Running the current Formosan QC validator on the published copy showed 3,883 V132 `html_entities_in_FORM_TRANSL` findings. The dev XML has 0 V132 findings.

This is intended as a comparison PR, not an assertion that all remaining Yedda QC is complete.

## Validation

Ran current FormosanBank validators on the changed file:

- `validate_xml`: 0 issues
- `validate_text`: no V132 findings remain; remaining findings are 4 HARD V121 W/M parentheses/slash cases plus existing SOFT review items
- `validate_glosses`: still reports the known missing-gloss issues where Yedda has segmentation without full glossing