### PR TITLE
Fix QC audio and utility edge cases

### DIFF
--- a/QC/cleaning/clean_audio.py
+++ b/QC/cleaning/clean_audio.py
@@ -2,6 +2,9 @@
 
 Consumes a `broken_audio.csv` produced by `QC/validation/validate_audio.py`
 and removes each listed `<AUDIO>` element from its containing XML file.
+When the CSV includes `element_id`, `start`, and `end` locator columns,
+the removal is scoped to that exact reference; legacy CSVs with only
+`xml_file`, `audio_file`, and `kind` still fall back to filename matching.
 Optionally also deletes the audio file from disk.
 
 CLI shape:
@@ -57,31 +60,90 @@ def group_by_xml(rows: list[dict]) -> dict[Path, list[dict]]:
     return out
 
 
+def _row_label(row: dict) -> str:
+    bits = [row.get("audio_file", "")]
+    if row.get("element_id"):
+        bits.append(f"id={row['element_id']}")
+    if row.get("start") or row.get("end"):
+        bits.append(f"{row.get('start', '')}-{row.get('end', '')}")
+    return " ".join(bit for bit in bits if bit)
+
+
+def _candidate_parents(root: etree._Element, row: dict) -> list[etree._Element]:
+    element_id = row.get("element_id", "")
+    if not element_id:
+        return [root]
+    if element_id == "TEXT":
+        return [root]
+    matches = [elem for elem in root.iter() if elem.get("id") == element_id]
+    return matches
+
+
+def _matches_audio_row(audio_elem: etree._Element, row: dict, root_audio: str | None) -> bool:
+    audio_file = row.get("audio_file", "")
+    if not audio_file:
+        return False
+
+    elem_file = audio_elem.get("file")
+    if elem_file:
+        if elem_file != audio_file:
+            return False
+    elif root_audio != audio_file:
+        return False
+
+    for attr in ("start", "end"):
+        expected = row.get(attr, "")
+        if expected and audio_elem.get(attr, "") != expected:
+            return False
+
+    return True
+
+
 def remove_audio_elements(
     xml_path: Path,
-    audio_filenames: list[str],
+    rows: list[dict],
 ) -> tuple[int, list[str]]:
-    """Remove every `<AUDIO file="<name>">` whose name is in `audio_filenames`.
+    """Remove the listed `<AUDIO>` elements from an XML file.
+
+    New `broken_audio.csv` rows carry element/range locators so duplicate
+    references to the same filename are not all removed by accident. Older
+    rows without locator columns intentionally preserve the historical
+    filename-only behavior.
 
     Returns (n_removed, missing_targets) — missing_targets is the
-    audio_filenames that were not found in the file (so the operator
+    rows that were not found in the file (so the operator
     can investigate, rather than silently ignored).
     """
     tree = etree.parse(str(xml_path))
     root = tree.getroot()
-    targets = set(audio_filenames)
-    found: set[str] = set()
+    root_audio = root.get("audio")
+    missing: list[str] = []
     n_removed = 0
-    # iter() is safe for removal because we collect first, then remove.
-    to_remove = [a for a in root.iter("AUDIO") if a.get("file") in targets]
-    for elem in to_remove:
-        found.add(elem.get("file"))
-        parent = elem.getparent()
-        if parent is not None:
-            parent.remove(elem)
-            n_removed += 1
+
+    for row in rows:
+        candidates: list[etree._Element] = []
+        for parent in _candidate_parents(root, row):
+            audio_iter = (
+                parent.findall("AUDIO")
+                if row.get("element_id") == "TEXT"
+                else parent.iter("AUDIO")
+            )
+            candidates.extend(
+                a for a in audio_iter
+                if _matches_audio_row(a, row, root_audio)
+            )
+
+        if not candidates:
+            missing.append(_row_label(row))
+            continue
+
+        for elem in candidates:
+            parent = elem.getparent()
+            if parent is not None:
+                parent.remove(elem)
+                n_removed += 1
+
     tree.write(str(xml_path), encoding="utf-8", xml_declaration=True)
-    missing = sorted(targets - found)
     return n_removed, missing
 
 
@@ -131,9 +193,9 @@ def main(argv: list[str] | None = None) -> int:
         audio_targets = [r["audio_file"] for r in xml_rows]
         kinds = [r.get("kind", "") for r in xml_rows]
         print(f"  {xml_path}")
-        for fname, kind in zip(audio_targets, kinds):
+        for row, kind in zip(xml_rows, kinds):
             tag = f" [{kind}]" if kind else ""
-            print(f"    - {fname}{tag}")
+            print(f"    - {_row_label(row)}{tag}")
 
         if not args.apply:
             continue
@@ -142,7 +204,7 @@ def main(argv: list[str] | None = None) -> int:
             print(f"    WARNING: XML file not found, skipping: {xml_path}", file=sys.stderr)
             continue
 
-        n_removed, missing = remove_audio_elements(xml_path, audio_targets)
+        n_removed, missing = remove_audio_elements(xml_path, xml_rows)
         n_removed_total += n_removed
         if missing:
             print(

--- a/QC/cleaning/clean_xml.py
+++ b/QC/cleaning/clean_xml.py
@@ -568,7 +568,10 @@ def analyze_and_modify_xml_file(
                 modified = False
 
                 for sentence in root.findall('.//S'):
+                    # Intentionally includes descendant W/M FORM tiers; they
+                    # receive the same punctuation/Unicode cleanup as S FORM.
                     form_elements = sentence.findall('.//FORM')
+                    sentence_removed = False
                     for form_element in form_elements:
                         if form_element is not None:
                             form_text = form_element.text
@@ -577,42 +580,50 @@ def analyze_and_modify_xml_file(
                             if warnings is not None:
                                 for ch, pos in _find_bopomofo(form_text):
                                     warnings.add("c007", xml_file, sentence.get("id"), ch, pos)
-                            if form_text != unicodedata.normalize("NFC", form_text):
-                                form_element.text = unicodedata.normalize("NFC", form_text)
+                            working_text = unicodedata.normalize("NFC", form_text)
+                            if form_text != working_text:
+                                form_element.text = working_text
                                 modified = True
 
                             # Handle specific <FORM> cases
-                            if "456otca" in form_text:  # Remove <S> if text contains 456otca
+                            if "456otca" in working_text:  # Remove <S> if text contains 456otca
                                 root.remove(sentence)
                                 modified = True
+                                sentence_removed = True
+                                break
                             else:
-                                if html.unescape(form_text) != form_text:  # Replace HTML entities
+                                unescaped_text = html.unescape(working_text)
+                                if unescaped_text != working_text:  # Replace HTML entities
                                     print('HTML entities found')
                                     # log the change
                                     with open(os.path.join(corpora_dir,"html_entities.log"), "a") as f:
                                         f.write(f"{xml_file}:\n")
-                                        f.write(f"Original: {form_text}\n")
-                                        f.write(f"Modified: {html.unescape(form_text)}\n\n")
-                                    form_element.text = html.unescape(form_text)
+                                        f.write(f"Original: {working_text}\n")
+                                        f.write(f"Modified: {unescaped_text}\n\n")
+                                    working_text = unescaped_text
+                                    form_element.text = working_text
                                     modified = True
                                 cleaned_form_text = clean_text(
-                                    form_text,
+                                    working_text,
                                     lang="na",
                                     xml_file=xml_file,
                                     s_id=sentence.get("id"),
                                     warnings=warnings,
                                     counter=counter,
                                 )
-                                if cleaned_form_text != form_text:
+                                if cleaned_form_text != working_text:
                                     form_element.text = cleaned_form_text
                                     modified = True
 
                                 # C022: warn on each '*' in any FORM (any position).
                                 # FORM text is preserved (no removal).
-                                if warnings is not None and "*" in form_text:
-                                    for i, ch in enumerate(form_text):
+                                if warnings is not None and "*" in cleaned_form_text:
+                                    for i, ch in enumerate(cleaned_form_text):
                                         if ch == "*":
                                             warnings.add("c022", xml_file, sentence.get("id"), ch, i)
+
+                    if sentence_removed:
+                        continue
 
                     # C012: handle hyphens in S-level FORM[@kindOf="standard"] only.
                     # Must run AFTER clean_text so any clean_text output is included.

--- a/QC/utilities/add_phonology.py
+++ b/QC/utilities/add_phonology.py
@@ -56,6 +56,12 @@ def get_files(path, language):
 
     return to_check
 
+
+def get_exploration_targets(corpora_path):
+    if os.path.isfile(corpora_path) and corpora_path.endswith('.xml'):
+        return [corpora_path]
+    return [os.path.join(corpora_path, x) for x in os.listdir(corpora_path)]
+
 def apply_standard(s_element, standard):
     form = s_element.find("FORM[@kindOf='standard']")
     if form.text:
@@ -86,8 +92,7 @@ def main(args):
     if not os.path.exists(standard_path):
         parser.error(f"The standard orthography files can't be found: {standard_path}")
     
-    to_explore = os.listdir(args.corpora_path)
-    to_explore = [os.path.join(args.corpora_path, x) for x in to_explore]
+    to_explore = get_exploration_targets(args.corpora_path)
 
     for corpus in to_explore:
         print(f"Processing corpus: {corpus}")

--- a/QC/utilities/standardize.py
+++ b/QC/utilities/standardize.py
@@ -56,6 +56,14 @@ def get_files(path, language):
 
     return to_check
 
+
+def get_exploration_targets(corpora_path, corpus=None):
+    if corpus:
+        return [os.path.join(corpora_path, corpus)]
+    if os.path.isfile(corpora_path) and corpora_path.endswith('.xml'):
+        return [corpora_path]
+    return [os.path.join(corpora_path, x) for x in os.listdir(corpora_path)]
+
 def apply_standard(s_element, standard):
     form = s_element.find("FORM[@kindOf='standard']")
     if form.text:
@@ -119,11 +127,7 @@ def main(args):
             reader = csv.DictReader(f, delimiter='\t')
             available_columns = reader.fieldnames
     
-    if args.corpus:
-        to_explore = [os.path.join(args.corpora_path, args.corpus)]
-    else:
-        to_explore = os.listdir(args.corpora_path)
-        to_explore = [os.path.join(args.corpora_path, x) for x in to_explore]
+    to_explore = get_exploration_targets(args.corpora_path, args.corpus)
 
     for corpus in to_explore:
         print(f"Processing corpus: {corpus}")
@@ -263,6 +267,8 @@ if __name__ == "__main__":
     if not os.path.exists(args.corpora_path):
         parser.error(f"The entered corpora path doesn't exists: {args.corpora_path}")
     if args.corpus:
+        if os.path.isfile(args.corpora_path):
+            parser.error("--corpus cannot be used when --corpora_path is a file.")
         if not os.path.exists(os.path.join(args.corpora_path, args.corpus)):
             parser.error(f"The entered corpus doesn't exist: {os.path.join(args.corpora_path, args.corpus)}")
     if args.language and args.language not in langs:

--- a/QC/validation/validate_audio.py
+++ b/QC/validation/validate_audio.py
@@ -5,7 +5,7 @@ broken audio in four classes:
 
   V100 missing       — file referenced by <AUDIO @file> not found
   V101 unloadable    — file present but mutagen/wave can't decode it
-  V102 silent        — RMS amplitude (WAV) or ffprobe silencedetect (MP3) below threshold
+  V102 silent        — RMS amplitude (WAV) or ffmpeg silencedetect below threshold
   V103 invalid_range — AUDIO/@start >= AUDIO/@end
 
 Plus two SOFT signals (warn, don't fail):
@@ -28,18 +28,20 @@ Legacy CSVs (`non_working_audio.csv`, `missing_audio.csv`,
 single `broken_audio.csv` with a `kind` column subsumes them. See
 B9.2 plan W2 / Open Question 3.
 """
-import argparse
 import array
+import argparse
 import csv
+import json
 import os
 import subprocess
 import sys
 import wave
 import xml.etree.ElementTree as ET
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
 from pathlib import Path
 
-from mutagen.mp3 import MP3
+from mutagen import File as MutagenFile
 from tqdm import tqdm
 
 # Make _finding importable whether we're run as a script or imported as a module.
@@ -66,6 +68,8 @@ KIND_TO_RULE = {
     "invalid_range": RULE_INVALID_RANGE,
 }
 
+AUDIO_EXTENSIONS = ('.mp3', '.wav', '.flac', '.ogg', '.m4a')
+
 
 # -----------------------------------------------------------------------------
 # Lang resolution (kept for legacy callers; not used by the new pipeline).
@@ -87,13 +91,16 @@ def get_lang(path, file):
 
 def get_audio_duration(file_path):
     """Return the duration of an audio file in seconds, or None on failure."""
+    suffix = Path(file_path).suffix.lower()
     try:
-        if file_path.endswith('.mp3'):
-            audio = MP3(file_path)
-            return audio.info.length
-        elif file_path.endswith('.wav'):
+        if suffix == '.wav':
             with wave.open(file_path, "rb") as wav_file:
                 return wav_file.getnframes() / wav_file.getframerate()
+        audio = MutagenFile(file_path)
+        if audio is not None and audio.info is not None:
+            duration = getattr(audio.info, "length", None)
+            if duration is not None and duration > 0:
+                return float(duration)
     except Exception:
         return None
     return None
@@ -123,12 +130,12 @@ def is_silent_wav(file_path, threshold=10):
         return None
 
 
-def is_silent_mp3(file_path, noise_db=-50, min_silence_sec=0.5):
-    """Return True if an MP3 appears silent end-to-end.
+def is_silent_encoded_audio(file_path, noise_db=-50, min_silence_sec=0.5):
+    """Return True if an encoded audio file appears silent end-to-end.
 
-    Uses ffprobe's silencedetect audio filter. We treat the file as
+    Uses ffmpeg's silencedetect audio filter. We treat the file as
     silent if every reported silence segment together covers (almost)
-    the entire duration. Returns None when ffprobe is unavailable or
+    the entire duration. Returns None when ffmpeg is unavailable or
     the probe fails (caller should escalate to "unloadable").
     """
     duration = get_audio_duration(file_path)
@@ -150,6 +157,8 @@ def is_silent_mp3(file_path, noise_db=-50, min_silence_sec=0.5):
         )
     except (FileNotFoundError, subprocess.TimeoutExpired):
         return None
+    if proc.returncode != 0:
+        return None
     output = proc.stderr.decode("utf-8", errors="ignore")
     total_silence = 0.0
     for line in output.splitlines():
@@ -164,18 +173,62 @@ def is_silent_mp3(file_path, noise_db=-50, min_silence_sec=0.5):
     return (total_silence / duration) >= 0.95
 
 
+def is_silent_mp3(file_path, noise_db=-50, min_silence_sec=0.5):
+    """Backward-compatible wrapper for callers/tests using the old helper name."""
+    return is_silent_encoded_audio(file_path, noise_db, min_silence_sec)
+
+
 def is_silent(file_path):
     """Dispatch silence detection on extension. Returns True/False/None."""
-    if file_path.lower().endswith(".wav"):
+    suffix = Path(file_path).suffix.lower()
+    if suffix == ".wav":
         return is_silent_wav(file_path)
-    if file_path.lower().endswith(".mp3"):
-        return is_silent_mp3(file_path)
+    if suffix in AUDIO_EXTENSIONS:
+        return is_silent_encoded_audio(file_path)
     return None
 
 
 # -----------------------------------------------------------------------------
 # Path resolution + reference collection
 # -----------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class AudioRef:
+    xml_path: str
+    element_id: str
+    audio_filename: str
+    form_text: str
+    start: str | None
+    end: str | None
+
+
+def _audio_location(ref: AudioRef) -> str:
+    return json.dumps(
+        {
+            "audio_file": ref.audio_filename,
+            "element_id": ref.element_id,
+            "start": ref.start or "",
+            "end": ref.end or "",
+        },
+        ensure_ascii=False,
+    )
+
+
+def _parse_audio_location(location: str | None) -> dict[str, str]:
+    if not location:
+        return {"audio_file": "", "element_id": "", "start": "", "end": ""}
+    try:
+        data = json.loads(location)
+    except (TypeError, json.JSONDecodeError):
+        return {"audio_file": location, "element_id": "", "start": "", "end": ""}
+    if not isinstance(data, dict):
+        return {"audio_file": location, "element_id": "", "start": "", "end": ""}
+    return {
+        "audio_file": str(data.get("audio_file") or ""),
+        "element_id": str(data.get("element_id") or ""),
+        "start": str(data.get("start") or ""),
+        "end": str(data.get("end") or ""),
+    }
 
 def resolve_audio_path(xml_file_path, xml_root, audio_root, audio_filename):
     xml_file = Path(xml_file_path)
@@ -200,11 +253,11 @@ def resolve_audio_path(xml_file_path, xml_root, audio_root, audio_filename):
 
 
 def _audio_extensions_ok(audio_filename: str) -> bool:
-    return audio_filename.lower().endswith(('.mp3', '.wav', '.flac', '.ogg', '.m4a'))
+    return audio_filename.lower().endswith(AUDIO_EXTENSIONS)
 
 
 def collect_sentence_refs(xml_root):
-    """Return list of (xml_path, element_id, audio_filename, form_text, start, end)."""
+    """Return S/W audio refs, including TEXT/@audio single-file refs."""
     refs = []
     for root, dirs, files in os.walk(xml_root):
         for file in files:
@@ -213,13 +266,15 @@ def collect_sentence_refs(xml_root):
                 try:
                     tree = ET.parse(xml_path)
                     root_elem = tree.getroot()
+                    text_audio_filename = root_elem.get('audio') if root_elem.tag == 'TEXT' else None
                     for elem in root_elem.findall('.//S') + root_elem.findall('.//W'):
                         audio_elem = elem.find('AUDIO')
                         form_elem = elem.find("FORM[@kindOf='original']")
                         if (audio_elem is not None
-                                and 'file' in audio_elem.attrib
                                 and form_elem is not None):
-                            audio_filename = audio_elem.attrib['file']
+                            audio_filename = audio_elem.attrib.get('file') or text_audio_filename
+                            if not audio_filename:
+                                continue
                             if not _audio_extensions_ok(audio_filename):
                                 continue
                             # Use itertext() to collect every textual chunk
@@ -235,14 +290,21 @@ def collect_sentence_refs(xml_root):
                             form_text = ''.join(form_elem.itertext())
                             start = audio_elem.attrib.get('start')
                             end = audio_elem.attrib.get('end')
-                            refs.append((xml_path, elem.attrib.get('id', ''),
-                                         audio_filename, form_text, start, end))
+                            refs.append(AudioRef(
+                                xml_path=xml_path,
+                                element_id=elem.attrib.get('id', ''),
+                                audio_filename=audio_filename,
+                                form_text=form_text,
+                                start=start,
+                                end=end,
+                            ))
                 except Exception as e:
                     print(f"Warning: Could not parse {xml_path}: {e}", file=sys.stderr)
     return refs
 
 
 def collect_text_audio_refs(xml_root):
+    """Return root-child TEXT/AUDIO refs with their own file attributes."""
     refs = []
     for root, dirs, files in os.walk(xml_root):
         for file in files:
@@ -259,7 +321,14 @@ def collect_text_audio_refs(xml_root):
                                     continue
                                 start = audio_elem.attrib.get('start')
                                 end = audio_elem.attrib.get('end')
-                                refs.append((xml_path, audio_filename, start, end))
+                                refs.append(AudioRef(
+                                    xml_path=xml_path,
+                                    element_id="TEXT",
+                                    audio_filename=audio_filename,
+                                    form_text="",
+                                    start=start,
+                                    end=end,
+                                ))
                 except Exception as e:
                     print(f"Warning: Could not parse {xml_path}: {e}", file=sys.stderr)
     return refs
@@ -288,20 +357,17 @@ def _check_invalid_range(start, end) -> bool:
 
 def _check_unloadable(audio_path: str) -> bool:
     """Return True if mutagen/wave cannot decode the file."""
+    suffix = Path(audio_path).suffix.lower()
     try:
-        if audio_path.lower().endswith('.mp3'):
-            audio = MP3(audio_path)
-            if audio is None or audio.info is None or not audio.info.length:
-                return True
-            return False
-        if audio_path.lower().endswith('.wav'):
+        if suffix == '.wav':
             with wave.open(audio_path, "rb") as wav_file:
                 if wav_file.getnframes() == 0 or wav_file.getframerate() == 0:
                     return True
             return False
     except Exception:
         return True
-    return False
+    duration = get_audio_duration(audio_path)
+    return duration is None or duration <= 0
 
 
 def validate_corpus(xml_root: Path, audio_root: Path,
@@ -319,65 +385,65 @@ def validate_corpus(xml_root: Path, audio_root: Path,
     duration_rows: list[tuple] = []
 
     # --- Invalid range (independent of file existence) ---
-    for xml_path, sent_id, audio_filename, form_text, start, end in refs:
-        if _check_invalid_range(start, end):
+    for ref in refs:
+        if _check_invalid_range(ref.start, ref.end):
             findings.append(Finding(
                 rule_id=RULE_INVALID_RANGE,
                 severity=Severity.HARD,
-                message=f"AUDIO @start={start} >= @end={end} (invalid range)",
-                path=Path(xml_path),
-                location=audio_filename,
+                message=f"AUDIO @start={ref.start} >= @end={ref.end} (invalid range)",
+                path=Path(ref.xml_path),
+                location=_audio_location(ref),
             ))
-    for xml_path, audio_filename, start, end in text_refs:
-        if _check_invalid_range(start, end):
+    for ref in text_refs:
+        if _check_invalid_range(ref.start, ref.end):
             findings.append(Finding(
                 rule_id=RULE_INVALID_RANGE,
                 severity=Severity.HARD,
-                message=f"AUDIO @start={start} >= @end={end} (invalid range)",
-                path=Path(xml_path),
-                location=audio_filename,
+                message=f"AUDIO @start={ref.start} >= @end={ref.end} (invalid range)",
+                path=Path(ref.xml_path),
+                location=_audio_location(ref),
             ))
 
     # --- Resolve files; missing ones get V100 immediately ---
     resolved_refs = []
-    for xml_path, sent_id, audio_filename, form_text, start, end in refs:
-        audio_path = resolve_audio_path(xml_path, xml_root, audio_root, audio_filename)
+    for ref in refs:
+        audio_path = resolve_audio_path(ref.xml_path, xml_root, audio_root, ref.audio_filename)
         if audio_path is None:
             findings.append(Finding(
                 rule_id=RULE_MISSING,
                 severity=Severity.HARD,
-                message=f"audio file not found: {audio_filename}",
-                path=Path(xml_path),
-                location=audio_filename,
+                message=f"audio file not found: {ref.audio_filename}",
+                path=Path(ref.xml_path),
+                location=_audio_location(ref),
             ))
         else:
-            resolved_refs.append((xml_path, sent_id, audio_filename, audio_path, form_text))
+            resolved_refs.append((ref, audio_path))
 
     resolved_text_refs = []
-    for xml_path, audio_filename, start, end in text_refs:
-        audio_path = resolve_audio_path(xml_path, xml_root, audio_root, audio_filename)
+    for ref in text_refs:
+        audio_path = resolve_audio_path(ref.xml_path, xml_root, audio_root, ref.audio_filename)
         if audio_path is None:
             findings.append(Finding(
                 rule_id=RULE_MISSING,
                 severity=Severity.HARD,
-                message=f"audio file not found: {audio_filename}",
-                path=Path(xml_path),
-                location=audio_filename,
+                message=f"audio file not found: {ref.audio_filename}",
+                path=Path(ref.xml_path),
+                location=_audio_location(ref),
             ))
         else:
-            resolved_text_refs.append((xml_path, audio_filename, audio_path))
+            resolved_text_refs.append((ref, audio_path))
 
     # --- For resolved files, check unloadable then silent (mutex per file) ---
-    for xml_path, sent_id, audio_filename, audio_path, form_text in tqdm(
+    for ref, audio_path in tqdm(
         resolved_refs, desc="checking sentence/word audio", disable=not sys.stderr.isatty()
     ):
         if _check_unloadable(audio_path):
             findings.append(Finding(
                 rule_id=RULE_UNLOADABLE,
                 severity=Severity.HARD,
-                message=f"audio file unreadable: {audio_filename}",
-                path=Path(xml_path),
-                location=audio_filename,
+                message=f"audio file unreadable: {ref.audio_filename}",
+                path=Path(ref.xml_path),
+                location=_audio_location(ref),
             ))
             continue  # Don't try silence/duration on a broken file.
         if check_silence:
@@ -386,9 +452,9 @@ def validate_corpus(xml_root: Path, audio_root: Path,
                 findings.append(Finding(
                     rule_id=RULE_SILENT,
                     severity=Severity.HARD,
-                    message=f"audio file is silent: {audio_filename}",
-                    path=Path(xml_path),
-                    location=audio_filename,
+                    message=f"audio file is silent: {ref.audio_filename}",
+                    path=Path(ref.xml_path),
+                    location=_audio_location(ref),
                 ))
                 # Fall through to also run the words/sec SOFT check; silent
                 # audio shouldn't suppress that signal.
@@ -401,36 +467,36 @@ def validate_corpus(xml_root: Path, audio_root: Path,
         # SOFT V105 finding, but the signal there is "speaker is too
         # slow," not "audio was unintelligible." Suppress to avoid the
         # false positive. Added 2026-06-08.
-        if duration is not None and duration > 0 and form_text.strip():
-            word_count = len(form_text.strip().split())
-            num_char = len(form_text.strip())
+        if duration is not None and duration > 0 and ref.form_text.strip():
+            word_count = len(ref.form_text.strip().split())
+            num_char = len(ref.form_text.strip())
             char_per_sec = num_char / duration
             words_per_sec = word_count / duration
             if (words_per_sec < .1 or char_per_sec > 17) or \
                (word_count < 5 and duration > 10) or \
                (word_count > 12 and duration < 7):
-                duration_rows.append((xml_path, audio_filename,
+                duration_rows.append((ref.xml_path, ref.audio_filename,
                                       round(words_per_sec, 2), round(char_per_sec, 2)))
                 findings.append(Finding(
                     rule_id=RULE_WORDS_PER_SEC,
                     severity=Severity.SOFT,
                     message=(f"words/sec={words_per_sec:.2f} chars/sec={char_per_sec:.2f} "
                              f"outside expected range"),
-                    path=Path(xml_path),
-                    location=audio_filename,
+                    path=Path(ref.xml_path),
+                    location=_audio_location(ref),
                 ))
 
     # --- TEXT-level: existence + unloadable + silence (no words/sec) ---
-    for xml_path, audio_filename, audio_path in tqdm(
+    for ref, audio_path in tqdm(
         resolved_text_refs, desc="checking TEXT-level audio", disable=not sys.stderr.isatty()
     ):
         if _check_unloadable(audio_path):
             findings.append(Finding(
                 rule_id=RULE_UNLOADABLE,
                 severity=Severity.HARD,
-                message=f"audio file unreadable: {audio_filename}",
-                path=Path(xml_path),
-                location=audio_filename,
+                message=f"audio file unreadable: {ref.audio_filename}",
+                path=Path(ref.xml_path),
+                location=_audio_location(ref),
             ))
             continue
         if check_silence:
@@ -439,9 +505,9 @@ def validate_corpus(xml_root: Path, audio_root: Path,
                 findings.append(Finding(
                     rule_id=RULE_SILENT,
                     severity=Severity.HARD,
-                    message=f"audio file is silent: {audio_filename}",
-                    path=Path(xml_path),
-                    location=audio_filename,
+                    message=f"audio file is silent: {ref.audio_filename}",
+                    path=Path(ref.xml_path),
+                    location=_audio_location(ref),
                 ))
 
     return findings, duration_rows
@@ -451,7 +517,16 @@ def validate_corpus(xml_root: Path, audio_root: Path,
 # Output writers
 # -----------------------------------------------------------------------------
 
-BROKEN_CSV_HEADER = ["xml_file", "audio_file", "kind", "rule_id", "message"]
+BROKEN_CSV_HEADER = [
+    "xml_file",
+    "audio_file",
+    "element_id",
+    "start",
+    "end",
+    "kind",
+    "rule_id",
+    "message",
+]
 DURATION_CSV_HEADER = ["xml_file", "audio_file", "words_per_sec", "chars_per_sec"]
 
 
@@ -465,7 +540,17 @@ def write_broken_csv(path: Path, findings: list[Finding]) -> None:
             if fnd.severity is not Severity.HARD:
                 continue
             kind = kind_by_rule.get(fnd.rule_id, "")
-            writer.writerow([str(fnd.path), fnd.location or "", kind, fnd.rule_id, fnd.message])
+            details = _parse_audio_location(fnd.location)
+            writer.writerow([
+                str(fnd.path),
+                details["audio_file"],
+                details["element_id"],
+                details["start"],
+                details["end"],
+                kind,
+                fnd.rule_id,
+                fnd.message,
+            ])
 
 
 def write_duration_csv(path: Path, rows: list[tuple]) -> None:
@@ -517,7 +602,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     p.add_argument("--xml_path", required=True,
                    help="root dir containing XML files (corpus's XML/ dir)")
     p.add_argument("--check_silence", action="store_true",
-                   help="enable silence detection (WAV via RMS, MP3 via ffprobe)")
+                   help="enable silence detection (WAV via RMS, encoded formats via ffmpeg)")
     p.add_argument("--log_dir", type=Path, default=None,
                    help="output dir for broken_audio.csv and audio_duration_issues.csv "
                         "(default: ./logs/ relative to cwd)")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,14 +2,14 @@ huggingface-hub==0.29.1
 lxml==5.3.0
 matplotlib==3.9.2
 mutagen==1.47.0
-numpy==2.0.2
+numpy==2.2.6
 pandas==2.2.3
 PyYAML==6.0.2
 regex==2024.11.6
 requests==2.32.3
 sacrebleu>=2.4.0
 scikit-learn==1.5.2
-scipy==1.13.1
+scipy==1.15.3
 seaborn==0.13.2
 tqdm==4.67.1
 pytest==8.3.4

--- a/tests/cleaners/test_clean_xml.py
+++ b/tests/cleaners/test_clean_xml.py
@@ -68,6 +68,31 @@ def test_html_entities_round_trip_without_double_encoding(tmp_path, fixtures_dir
         )
 
 
+def test_html_unescape_happens_before_other_form_cleanups(tmp_path):
+    """A FORM needing both html.unescape and whitespace cleanup should keep both.
+
+    Regression pin for the branch where the cleaner wrote the unescaped text,
+    then ran clean_text on the original escaped string and could overwrite the
+    unescape when whitespace/punctuation cleanup also changed the same FORM.
+    """
+    work = tmp_path / "double_encoded.xml"
+    work.write_text(
+        '<?xml version="1.0" encoding="utf-8"?>\n'
+        '<TEXT id="T" citation="t" BibTeX_citation="@t{t}" '
+        'copyright="t" xml:lang="ami">'
+        '<S id="S_1">'
+        '<FORM kindOf="original">&amp;quot;foo  bar&amp;quot;</FORM>'
+        '<TRANSL xml:lang="eng">x</TRANSL>'
+        '</S>'
+        '</TEXT>',
+        encoding="utf-8",
+    )
+    proc = _run_clean(tmp_path)
+    assert proc.returncode == 0, f"stderr: {proc.stderr}"
+    forms = _form_texts(work)
+    assert forms == ['"foo bar"'], f"expected unescaped and whitespace-cleaned FORM: {forms!r}"
+
+
 def test_whitespace_is_normalized(tmp_path, fixtures_dir, copy_fixture):
     work = copy_fixture(fixtures_dir / "xml_with_whitespace_problems.xml", tmp_path)
     proc = _run_clean(tmp_path)

--- a/tests/cleaning/test_clean_audio.py
+++ b/tests/cleaning/test_clean_audio.py
@@ -53,7 +53,10 @@ def _audio_refs(xml_path: Path) -> list[str]:
 def _write_broken_csv(path: Path, rows: list[dict]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with open(path, "w", newline="", encoding="utf-8") as f:
-        writer = csv.DictWriter(f, fieldnames=["xml_file", "audio_file", "kind"])
+        writer = csv.DictWriter(
+            f,
+            fieldnames=["xml_file", "audio_file", "element_id", "start", "end", "kind"],
+        )
         writer.writeheader()
         writer.writerows(rows)
 
@@ -130,6 +133,53 @@ def test_apply_removes_audio_element(tmp_path):
     refs = _audio_refs(xml)
     assert audio_filename not in refs, f"broken audio not removed; refs={refs}"
     assert "good.wav" in refs, "untargeted audio incorrectly removed"
+
+
+def test_apply_uses_locator_columns_for_repeated_audio_filename(tmp_path):
+    corpus, xml_dir, audio_dir = _make_corpus(tmp_path)
+    audio_filename = "shared.wav"
+    (audio_dir / audio_filename).write_bytes(b"")
+
+    xml = xml_dir / "test.xml"
+    root = ET.Element("TEXT", attrib={
+        "id": "TEST_AUDIO",
+        "citation": "test",
+        "BibTeX_citation": "@test{test}",
+        "copyright": "test",
+        "xml:lang": "ami",
+    })
+    for s_id, start, end in (("S_1", "0", "1"), ("S_2", "1", "2")):
+        s = ET.SubElement(root, "S", attrib={"id": s_id})
+        ET.SubElement(s, "FORM", attrib={"kindOf": "original"}).text = s_id
+        ET.SubElement(s, "FORM", attrib={"kindOf": "standard"}).text = s_id
+        ET.SubElement(s, "AUDIO", attrib={
+            "file": audio_filename,
+            "start": start,
+            "end": end,
+        })
+    ET.ElementTree(root).write(str(xml), encoding="utf-8", xml_declaration=True)
+
+    broken_csv = tmp_path / "broken_audio.csv"
+    _write_broken_csv(broken_csv, [{
+        "xml_file": str(xml),
+        "audio_file": audio_filename,
+        "element_id": "S_2",
+        "start": "1",
+        "end": "2",
+        "kind": "invalid_range",
+    }])
+
+    proc = _run(corpus, broken_csv, "--apply")
+    assert proc.returncode == 0, f"stderr: {proc.stderr}"
+    root = ET.parse(xml).getroot()
+    remaining = [
+        (s.get("id"), s.find("AUDIO").get("start"))
+        for s in root.findall(".//S")
+        if s.find("AUDIO") is not None
+    ]
+    assert remaining == [("S_1", "0")], (
+        "locator row should remove only S_2's AUDIO, not every shared.wav reference"
+    )
 
 
 def test_apply_removes_regardless_of_kind(tmp_path):

--- a/tests/utilities/test_add_phonology.py
+++ b/tests/utilities/test_add_phonology.py
@@ -89,6 +89,24 @@ def test_single_dialect_label_resolves_to_lone_ipa_column(tmp_path):
     )
 
 
+def test_accepts_single_xml_corpora_path(tmp_path):
+    xml_path = tmp_path / "y.xml"
+    xml_path.write_text(
+        '<TEXT xml:lang="tao" dialect="Yami">'
+        '<S id="1">'
+        '<FORM kindOf="original">ngaro</FORM>'
+        '<FORM kindOf="standard">ngaro</FORM>'
+        "</S></TEXT>",
+        encoding="utf-8",
+    )
+    proc = _run(xml_path)
+    combined = proc.stdout + proc.stderr
+    assert "Error" not in combined, f"unexpected error: {combined!r}"
+    assert _phon_texts(xml_path, "standard"), (
+        f"no standard PHON added for direct XML path; output: {combined!r}"
+    )
+
+
 def test_multi_dialect_resolves_via_dialect_column(tmp_path):
     """Amis (multi-dialect) with dialect="Coastal" resolves the Coastal column.
 

--- a/tests/utilities/test_standardize.py
+++ b/tests/utilities/test_standardize.py
@@ -72,6 +72,13 @@ def test_copy_adds_standard_tier_when_only_original_exists(tmp_path, fixtures_di
     ]
 
 
+def test_copy_accepts_single_xml_corpora_path(tmp_path, fixtures_dir, copy_fixture):
+    work = copy_fixture(fixtures_dir / "valid_original_only.xml", tmp_path)
+    proc = _run_standardize(["--copy", "--corpora_path", str(work)])
+    assert proc.returncode == 0, f"stderr: {proc.stderr}"
+    assert _standard_forms(work) == _original_forms(work)
+
+
 def test_copy_overwrites_existing_standard_tier(tmp_path, fixtures_dir, copy_fixture):
     work = copy_fixture(fixtures_dir / "valid_both_tiers.xml", tmp_path)
     proc = _run_standardize(["--copy", "--corpora_path", str(tmp_path)])

--- a/tests/validators/test_validate_audio.py
+++ b/tests/validators/test_validate_audio.py
@@ -125,6 +125,44 @@ def test_missing_audio_file_lands_with_kind_missing(tmp_path):
     assert any(r["audio_file"] == "does_not_exist.wav" and r["kind"] == "missing" for r in rows), (
         f"expected kind=missing entry; rows={rows}"
     )
+    row = next(r for r in rows if r["audio_file"] == "does_not_exist.wav")
+    assert row["element_id"] == "S_1"
+    assert row["start"] == "0"
+    assert row["end"] == "1"
+
+
+def test_text_audio_attribute_fileless_child_refs_are_validated(tmp_path):
+    """TEXT/@audio is the shared-file pattern allowed by validate_xml.py.
+
+    Sentence/word AUDIO elements in this mode carry start/end but no own
+    file attribute. validate_audio must still resolve/check the shared
+    TEXT-level file rather than silently skipping the child range.
+    """
+    corpus, xml_dir, audio_dir = _make_corpus(tmp_path)
+    xml = xml_dir / "test.xml"
+    root = ET.Element("TEXT", attrib={
+        "id": "TEST",
+        "citation": "t",
+        "BibTeX_citation": "@t{t}",
+        "copyright": "t",
+        "xml:lang": "ami",
+        "audio": "shared.wav",
+    })
+    s = ET.SubElement(root, "S", attrib={"id": "S_1"})
+    ET.SubElement(s, "FORM", attrib={"kindOf": "original"}).text = "Halo."
+    ET.SubElement(s, "AUDIO", attrib={"start": "0", "end": "1"})
+    ET.ElementTree(root).write(str(xml), encoding="utf-8", xml_declaration=True)
+
+    log_dir = tmp_path / "logs"
+    proc = _run(xml_dir, audio_dir, log_dir)
+    assert proc.returncode != 0, "missing shared TEXT/@audio file should be HARD"
+    rows = _read_broken_csv(log_dir)
+    assert any(
+        r["audio_file"] == "shared.wav"
+        and r["element_id"] == "S_1"
+        and r["kind"] == "missing"
+        for r in rows
+    ), f"expected missing row for shared TEXT/@audio child ref; rows={rows}"
 
 
 def test_unloadable_audio_file_lands_with_kind_unloadable(tmp_path):


### PR DESCRIPTION
## Summary

- Teach `validate_audio.py` to collect sentence/word audio references that rely on root `TEXT/@audio`, including fileless child `<AUDIO start/end>` ranges.
- Decode duration/unloadable checks for all accepted audio extensions via `wave`/Mutagen, and use ffmpeg silence detection for encoded formats.
- Add locator columns to `broken_audio.csv` and update `clean_audio.py` to remove exact references when `element_id/start/end` are present, while preserving legacy filename-only CSV behavior.
- Fix `clean_xml.py` HTML-unescape ordering so later cleanup does not reintroduce escaped text, while documenting that descendant W/M FORM cleanup is intentional.
- Allow `standardize.py` and `add_phonology.py` to accept a direct single-XML `--corpora_path` as documented.

## Validation

- `python3 -m py_compile QC/validation/validate_audio.py QC/cleaning/clean_audio.py QC/cleaning/clean_xml.py QC/utilities/standardize.py QC/utilities/add_phonology.py`
- `git diff --check`
- `.venv/bin/python -m pytest tests/validators/test_validate_audio.py tests/cleaning/test_clean_audio.py tests/cleaners/test_clean_xml.py tests/utilities/test_standardize.py tests/utilities/test_add_phonology.py -q` -> 39 passed
- `.venv/bin/python -m pytest -q` -> 614 passed, 1 skipped