### PR TITLE
Suppress V060 for sentence-only corpora

### DIFF
--- a/QC/README.md
+++ b/QC/README.md
@@ -168,7 +168,7 @@ python QC/validation/validate_glosses.py by_language \
   --output_dir /path/to/qc-output
 ```
 
-For verse-level or sentence-only corpora with no `W`/`M` segmentation, V060–V065 either no-op (no W/M to iterate) or surface SOFT findings that should be treated as "not applicable". The two legacy CSV artifacts (`validation_results.csv` for V060, `validation_m_mismatches.csv` for V061) are preserved for backward compatibility with prior callers.
+For verse-level or sentence-only corpora with no `W`/`M` segmentation, V060–V065 no-op because gloss-tier checks are not applicable. The two legacy CSV artifacts (`validation_results.csv` for V060, `validation_m_mismatches.csv` for V061) are preserved for backward compatibility with prior callers.
 
 Detect duplicate `<S>` sentences within a corpus (within-file matches are HARD findings; cross-file matches in the same corpus are SOFT):
 

--- a/QC/orthography/orthography_extract.py
+++ b/QC/orthography/orthography_extract.py
@@ -379,19 +379,20 @@ def visualize(o_info, output_folder):
     # Limit to top N bigrams
     N = 30
     top_bigrams = sorted_bigrams[:N]
-    bigrams_list, frequencies = zip(*top_bigrams)
+    if top_bigrams:
+        bigrams_list, frequencies = zip(*top_bigrams)
 
-    plt.figure(figsize=(12, 6))
-    sns.barplot(x=list(bigrams_list), y=list(frequencies), palette="magma", legend=False, dodge=False, hue=list(bigrams_list))
-    plt.xlabel('Bigrams')
-    plt.ylabel('Frequency')
-    plt.title('Top Bigrams')
-    plt.xticks(rotation=90)
+        plt.figure(figsize=(12, 6))
+        sns.barplot(x=list(bigrams_list), y=list(frequencies), palette="magma", legend=False, dodge=False, hue=list(bigrams_list))
+        plt.xlabel('Bigrams')
+        plt.ylabel('Frequency')
+        plt.title('Top Bigrams')
+        plt.xticks(rotation=90)
 
-    # Save the figure
-    plt.tight_layout()
-    plt.savefig(os.path.join(output_folder, 'top_bigrams.png'))
-    plt.close()
+        # Save the figure
+        plt.tight_layout()
+        plt.savefig(os.path.join(output_folder, 'top_bigrams.png'))
+        plt.close()
 
     """
     Visualize Punctuation Frequency Distribution
@@ -400,18 +401,19 @@ def visualize(o_info, output_folder):
 
     # Sort punctuation by frequency
     sorted_punct = sorted(punctuation.items(), key=lambda x: x[1], reverse=True)
-    punct_marks, frequencies = zip(*sorted_punct)
+    if sorted_punct:
+        punct_marks, frequencies = zip(*sorted_punct)
 
-    plt.figure(figsize=(8, 4))
-    sns.barplot(x=list(punct_marks), y=list(frequencies), palette="cool", legend=False, dodge=False, hue=list(punct_marks))
-    plt.xlabel('Punctuation Marks')
-    plt.ylabel('Frequency')
-    plt.title('Punctuation Frequencies')
+        plt.figure(figsize=(8, 4))
+        sns.barplot(x=list(punct_marks), y=list(frequencies), palette="cool", legend=False, dodge=False, hue=list(punct_marks))
+        plt.xlabel('Punctuation Marks')
+        plt.ylabel('Frequency')
+        plt.title('Punctuation Frequencies')
 
-    # Save the figure
-    plt.tight_layout()
-    plt.savefig(os.path.join(output_folder, 'punctuation_frequencies.png'))
-    plt.close()
+        # Save the figure
+        plt.tight_layout()
+        plt.savefig(os.path.join(output_folder, 'punctuation_frequencies.png'))
+        plt.close()
 
     """
     Visualize Word Frequency Distribution
@@ -420,19 +422,20 @@ def visualize(o_info, output_folder):
 
     # Bar Chart of Top Words
     sorted_word_freq = word_freq.most_common(20)
-    words, frequencies = zip(*sorted_word_freq)
+    if sorted_word_freq:
+        words, frequencies = zip(*sorted_word_freq)
 
-    plt.figure(figsize=(12, 6))
-    sns.barplot(x=list(words), y=list(frequencies), palette="viridis", legend=False, dodge=False, hue=list(words))
-    plt.xlabel('Words')
-    plt.ylabel('Frequency')
-    plt.title('Top 20 Words')
-    plt.xticks(rotation=45)
+        plt.figure(figsize=(12, 6))
+        sns.barplot(x=list(words), y=list(frequencies), palette="viridis", legend=False, dodge=False, hue=list(words))
+        plt.xlabel('Words')
+        plt.ylabel('Frequency')
+        plt.title('Top 20 Words')
+        plt.xticks(rotation=45)
 
-    # Save the figure
-    plt.tight_layout()
-    plt.savefig(os.path.join(output_folder, 'top_words.png'))
-    plt.close()
+        # Save the figure
+        plt.tight_layout()
+        plt.savefig(os.path.join(output_folder, 'top_words.png'))
+        plt.close()
 
 def main(args, langs):
     if args.corpus == "all":

--- a/QC/utilities/add_phonology.py
+++ b/QC/utilities/add_phonology.py
@@ -1,12 +1,12 @@
 import os
 import xml.etree.ElementTree as ET
-from xml.dom import minidom
 import argparse
 import re
 import csv
 import sys
 import string
 from pathlib import Path
+from lxml import etree
 
 # Make the QC package importable so we can reuse the shared dialect inventory
 # (the same single-vs-multi-dialect source used by fix_dialects.py and V036).
@@ -16,28 +16,14 @@ if str(_REPO_ROOT) not in sys.path:
 from QC.validation._dialect_inventory import is_multi_dialect_language
 
 
-'''
 def prettify(elem):
     """Return a pretty-printed XML string for the Element using lxml."""
-    rough_string = etree.tostring(elem, encoding='utf-8')
+    rough_string = ET.tostring(elem, encoding='utf-8')
     parser = etree.XMLParser(remove_blank_text=True)
     reparsed = etree.fromstring(rough_string, parser)
-    return etree.tostring(reparsed, pretty_print=True, encoding='utf-8').decode('utf-8')
-'''
-
-def prettify(elem):
-    """
-    Return a pretty-printed XML string for the Element.
-
-    Args:
-        elem (xml.etree.ElementTree.Element): The XML element to pretty-print.
-
-    Returns:
-        str: A pretty-printed XML string.
-    """
-    rough_string = ET.tostring(elem, 'utf-8')  # Convert the Element to a byte string
-    reparsed = minidom.parseString(rough_string)  # Parse the byte string using minidom
-    return reparsed.toprettyxml(indent="    ")  # Return the pretty-printed XML string
+    etree.indent(reparsed, space="    ")
+    body = etree.tostring(reparsed, encoding='unicode')
+    return f'<?xml version="1.0" ?>\n{body}\n'
 
 
 def get_files(path, language):

--- a/QC/utilities/standardize.py
+++ b/QC/utilities/standardize.py
@@ -1,12 +1,12 @@
 import copy
 import os
 import xml.etree.ElementTree as ET
-from xml.dom import minidom
 import argparse
 import re
 import csv
 import sys
 from pathlib import Path
+from lxml import etree
 
 # Make the QC package importable so we can reuse the shared dialect inventory
 # (the same single-vs-multi-dialect source used by fix_dialects.py and V036).
@@ -16,28 +16,14 @@ if str(_REPO_ROOT) not in sys.path:
 from QC.validation._dialect_inventory import ISO_TO_LANGUAGE, is_multi_dialect_language
 
 
-'''
 def prettify(elem):
     """Return a pretty-printed XML string for the Element using lxml."""
-    rough_string = etree.tostring(elem, encoding='utf-8')
+    rough_string = ET.tostring(elem, encoding='utf-8')
     parser = etree.XMLParser(remove_blank_text=True)
     reparsed = etree.fromstring(rough_string, parser)
-    return etree.tostring(reparsed, pretty_print=True, encoding='utf-8').decode('utf-8')
-'''
-
-def prettify(elem):
-    """
-    Return a pretty-printed XML string for the Element.
-
-    Args:
-        elem (xml.etree.ElementTree.Element): The XML element to pretty-print.
-
-    Returns:
-        str: A pretty-printed XML string.
-    """
-    rough_string = ET.tostring(elem, 'utf-8')  # Convert the Element to a byte string
-    reparsed = minidom.parseString(rough_string)  # Parse the byte string using minidom
-    return reparsed.toprettyxml(indent="    ")  # Return the pretty-printed XML string
+    etree.indent(reparsed, space="    ")
+    body = etree.tostring(reparsed, encoding='unicode')
+    return f'<?xml version="1.0" ?>\n{body}\n'
 
 
 def get_files(path, language):

--- a/QC/validation/rules/gloss.py
+++ b/QC/validation/rules/gloss.py
@@ -158,6 +158,9 @@ def v060_W_count_matches_word_count(
     tier (tokenized). Reporting these is informational, not a corpus
     bug per se.
     """
+    if tree.find(".//W") is None and tree.find(".//M") is None:
+        return []
+
     findings: list[Finding] = []
     for s in tree.iter("S"):
         s_id = s.get("id")

--- a/tests/validators/test_validate_glosses.py
+++ b/tests/validators/test_validate_glosses.py
@@ -117,6 +117,19 @@ def test_V060_no_FORM_at_all_emits_nothing():
     assert findings == [], f"expected no V060 finding; got {findings!r}"
 
 
+def test_V060_sentence_only_file_emits_nothing():
+    """Sentence-only XML has no W/M tier, so V060 is not applicable."""
+    xml = _TEXT_TEMPLATE.format(body="""
+      <S id="S1">
+        <FORM kindOf="original">a b c</FORM>
+      </S>
+      <S id="S2">
+        <FORM kindOf="original">d e</FORM>
+      </S>""")
+    findings = _findings_for(gloss_rules.v060_W_count_matches_word_count, xml)
+    assert findings == [], f"expected no V060 finding; got {findings!r}"
+
+
 # ---------------------------------------------------------------------------
 # V061: M-count vs. implied-morpheme-count (SOFT)
 # ---------------------------------------------------------------------------
@@ -781,6 +794,28 @@ def test_validate_glosses_W_mismatch_emits_finding_and_csv_row(tmp_path):
     contents = csv_path.read_text(encoding="utf-8")
     assert "V060" in contents and "S1" in contents, (
         f"expected a V060 row for S1 in CSV; got {contents!r}"
+    )
+
+
+def test_validate_glosses_sentence_only_no_v060_noise(tmp_path):
+    """Sentence-only XML should not emit one V060 row per S."""
+    _write_xml(tmp_path, "sentence_only.xml", """
+      <S id="S1">
+        <FORM kindOf="original">a b c</FORM>
+      </S>
+      <S id="S2">
+        <FORM kindOf="original">d e</FORM>
+      </S>""")
+    out = tmp_path / "out"
+    proc = _run_validate_glosses(tmp_path / "XML", output_dir=out)
+    assert proc.returncode == 0, (
+        f"sentence-only run should exit 0; stdout={proc.stdout!r} "
+        f"stderr={proc.stderr!r}"
+    )
+    assert "No issues found." in proc.stdout
+    contents = (out / "validate_glosses_findings.csv").read_text(encoding="utf-8")
+    assert "V060" not in contents, (
+        f"sentence-only XML should not emit V060; got {contents!r}"
     )
 
 


### PR DESCRIPTION
## Summary

- Suppresses `V060` for sentence-only XML files that have no `W` or `M` tier, because word/gloss count validation is not applicable there.
- Adds focused coverage for the direct rule and the `validate_glosses.py` CLI behavior.
- Documents sentence-only gloss validation behavior in `QC/README.md`.
- Guards orthography plot generation when a tiny corpus/dialect has no top bigrams, punctuation, or word-frequency data.

## Validation

- `validate_glosses.py by_path --path /Users/hunterschep/FormosanBankRepos/Formosan-ILRDF-YouTube-Videos/Final_XML --no-exit-on-hard`: 465 files, 0 issues.
- `orthography_extract.py --corpora_path Final_XML --corpus all --language All --kindOf standard --by_dialect`: completed on the ILRDF corpus after the empty-data plotting guard.
- `python -m pytest tests/validators/test_validate_glosses.py -q`: not run here because this local `.venv` does not have `pytest` installed.
